### PR TITLE
ci: don't specify node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,19 +12,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node: [12, 14]
-
-    name: Node ${{ matrix.node }}
+    name: Node
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Node ${{ matrix.node-version }}
+      - name: Setup Node
         uses: actions/setup-node@v2.4.1
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.18.2--canary.625.4611c05.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite-dev-config@0.18.2--canary.625.4611c05.0
  # or 
  yarn add vega-lite-dev-config@0.18.2--canary.625.4611c05.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
